### PR TITLE
Verbesserung der Maintenance.md

### DIFF
--- a/docs/development/maintenance-coordinator.md
+++ b/docs/development/maintenance-coordinator.md
@@ -15,33 +15,31 @@
 ## Role of the Coordinator
 
 The Coordinator is not the owner of the component but much more the curator. 
-The coordinator ensures the quality of contributions to the component 
-and makes it possible for others to commit. The coordinator is responsible 
-that the documentation is kept up to date by the contributors and that the 
-guidelines of the component are met. The coordinator moderates the discussion on 
-finding a vision and on the development. The coordinator further is contact 
-for any sort of question that may arise about the respective component.
+The coordinator ensures the quality of contributions to the component and makes
+it possible for others to contribute. The coordinator is responsible that the
+documentation is kept up to date by the contributors and that the guidelines
+of the component are met. The coordinator moderates the discussion to find a
+vision and about the development. The coordinator further is contact for any
+sort of question that may arise about the respective component.
 
-The motivation of the coordinator is mostly driven by the need of a 
-reliable component for a certain aspect. Further the coordinator is 
-probably the most attractive contractor for clients aiming to change 
-aspects of the component due to the very indepth know how and the 
-listing as coordinator. 
+The motivation of the coordinator is mostly driven by the need of a reliable
+component for a certain aspect. Further, the coordinator is probably the most
+attractive contractor for clients aiming to change aspects of the component due
+to the very in-depth know-how and the listing as coordinator.
 
 The PM and the TB appoint or replace coordinators. The coordinator role belongs to
-the person, not the company, since the role builds on social capital in the community
+a person, not a company. Since the role builds on social capital in the community
 and a vision of the component it will be near impossible to leave that role at a
-company.
+company when moving on.
 
 It is encouraged that two people share the role of the coordinator for one
 component to enhance it's [Bus factor](https://en.wikipedia.org/wiki/Bus_factor).
 
 <a name="change-management"></a>
 ## Change Management
-Everybody may contribute to any aspect of the component. Such contributions 
-are handed in by pull requests or some other source of data if declared so in
-the components guidelines. Note that the general
-[contribution guideline](https://github.com/ILIAS-eLearning/ILIAS/blob/release_5-3/docs/documentation/contributing.md)
+Everybody may contribute to any aspect of the component. Such contributions are
+handed in by pull requests or some other source of data if declared so in the
+components guidelines. Note that the general [contribution guideline](https://github.com/ILIAS-eLearning/ILIAS/blob/release_5-3/docs/documentation/contributing.md)
 also apply for components managed by the coordinator model. The coordinator is
 called upon to define additional criteria and processes for the component (e.g.
 UI-components). This is the gain of this model: PRs cannot be rejected arbitrarily.
@@ -50,11 +48,11 @@ Pull requests on the public interface must be accepted by the JF. The coordinato
 gives a recommendation to the JF on whether to accept or decline the PR. The
 decision of the JF may be implicit if no objections to the recommendation of the
 coordinator is made. If no agreement is achieved in the JF, the Technical Board
-will decide upon the request. Further note in case two people sharing the role of
-the coordinator, that the feedback of one coordinator is enough for a request to
-be processed further. If both give feedback, the points of both coordinators must
-be respected. If the coordinators give contradictory feedback, the coordinators
-must resolve their differences before further processing.
+will decide upon the request. Further note, that in the case of two ore more people
+sharing the role of the coordinator, the feedback of one coordinator is enough for a
+request to be processed further. If both give feedback, the points of both
+coordinators must be respected. If the coordinators give contradictory feedback,
+the coordinators must resolve their differences before further processing.
 
 Final implementations without further changes on the interface do not need formal
 approval by the JF. The merge of the implementation is performed by the coordinator
@@ -73,53 +71,52 @@ focus on code quality, a low amount of bugs should be expected.
 
 <a name="scenarios"></a>
 ## Scenarios
-This maintainance model is suited for components that have the potential 
-to grow too large to be handled by one single developer and therefore highly 
-benefit from contributions among different developers and even service providers. 
-It is further important that the component is of modular structure with different 
-parts following a similar scheme. It is especially suited, if some component is 
-of a critical importance for many other components, since it is designed to allow 
-a collaborative development of the vision for such a key aspect.
+This maintainance-model is suited for components that have the potential to grow
+too large to be handled by one single developer and therefore highly benefit
+from contributions from different developers and even service providers. It is
+further important that the component is of modular structure with different parts
+following a similar scheme. It is especially suited if some component is of a
+critical importance for many other components, since it is designed to allow a
+collaborative development of the vision for such a key-aspect.
 
 <a name="expectations"></a>
 ## What can be expected of a coordinator?
-* The coordinator MUST moderate the discussion on finding a vision on 
-the development of the component. The coordinator SHOULD document that
-vision publicly in a file called `ROADMAP.md` in the root of the
-components directory.
-* The coordinator MUST give recommendations to the JF whether to accept 
-or decline changes.
-* If two people share the role of the coordinator and give contradictory 
-feedback for a change request, they MUST resolve the conflict as quickly
-as possible and publish a new feedback without contradictions. 
-* If two people share the role of the coordinator they MUST define whom of
+* The coordinator MUST moderate discussions to find a vision on the development
+of the component. The coordinator SHOULD document that vision publicly in a file
+called `ROADMAP.md` in the root of the components directory.
+* The coordinator MUST give recommendations to the JF whether to accept or
+decline changes.
+* If two or more people share the role of the coordinator and give contradictory
+feedback for a change request, they MUST resolve the conflict as quickly as possible
+and publish a new feedback without contradictions.
+* If two or more people share the role of the coordinator they MUST define whom of
 them is contact person for Mantis bug reports as well as for other applicationsi
 that do not support more than one contact.
-* If two people share the role of the coordinator they MAY give feedback
-the different aspects of a change request. In such a case, both feedbacks
-MUST be considered.
-* The coordinator MUST accept decisions of the Technical Board on change 
-requests in case of disagreement on the JF.
-* The coordinator MUST review final implementation of some accepted 
-interface change or organize some substitute to perform the review.
-* The coordinator MAY ask for funding to perform the review.
-* The coordinator MAY ask to split some interface change or implementation 
-into multiple pieces to make the change easier to understand.
-* The coordinator MUST ensure, that the documentation of the component is 
-up to date. The coordinator MAY ask to update the documentation as a condition 
-for accepting some change request.
-* The coordinator MUST ensure, that the automated unit tests are kept up 
-to date. The coordinator MAY ask other developers to write and update those 
-tests in their own development.
+* If two or more people share the role of the coordinator they MAY give feedback
+on different aspects of a change request. In such a case, both feedbacks MUST be
+considered.
+* The coordinator MUST accept decisions of the Technical Board on change requests
+in case of disagreement on the JF.
+* The coordinator MUST review final implementation of some accepted interface
+change or organize some substitute to perform the review.
+* The coordinator MAY ask for funding to perform a review.
+* The coordinator MAY ask to split some interface change or implementation into
+multiple pieces to make the change easier to understand.
+* The coordinator MUST ensure, that the documentation of the component is up to
+date. The coordinator MAY ask to update the documentation as a condition for
+accepting some change request.
+* The coordinator MUST ensure, that the automated unit tests are kept up to date.
+The coordinator MAY ask other developers to write and update those tests in their
+own development.
 * The coordinator MUST assign unassigned issues to the responsible developer.
-* The coordinator SHOULD devise some guidelines concerning the processes 
-around the respective component fitting it's exact needs as done so for the 
-UI-Service. Such guidelines MUST be accepted by the JF.
-* The coordinator MUST follow the rules given for the components, especially 
-for contributing code. The coordinator has no special rights in this regard. 
-E.g. if a pull request is needed in certain scenarios, the coordinator 
-would need to create as well.
+* The coordinator SHOULD devise some guidelines concerning the processes around
+the respective component fitting it's exact needs as done so for the UI-Service.
+Such guidelines MUST be accepted by the JF.
+* The coordinator MUST follow the rules given for the components, especially for
+contributing code. The coordinator has no special rights in this regard. E.g. if
+a pull request is needed in certain scenarios, the coordinator would need to create
+one as well.
 
-**Please note:** The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", 
-"SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and  "OPTIONAL" 
-in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+**Please note:** The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
+NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and  "OPTIONAL" in this
+document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).

--- a/docs/development/maintenance-coordinator.md
+++ b/docs/development/maintenance-coordinator.md
@@ -14,23 +14,23 @@
 <a name="role-of-a-coordinator"></a>
 ## Role of the Coordinator
 
-The Coordinator is not the owner of the component but much more the curator. 
+The Coordinator is not the owner of the component but rather the curator. 
 The coordinator ensures the quality of contributions to the component and makes
 it possible for others to contribute. The coordinator is responsible that the
 documentation is kept up to date by the contributors and that the guidelines
 of the component are met. The coordinator moderates the discussion to find a
-vision and about the development. The coordinator further is contact for any
+vision and about the development. The coordinator further acts as single point of contact for any
 sort of question that may arise about the respective component.
 
 The motivation of the coordinator is mostly driven by the need of a reliable
-component for a certain aspect. Further, the coordinator is probably the most
+component. Further, the coordinator is probably the most
 attractive contractor for clients aiming to change aspects of the component due
 to the very in-depth know-how and the listing as coordinator.
 
 The PM and the TB appoint or replace coordinators. The coordinator role belongs to
 a person, not a company. Since the role builds on social capital in the community
-and a vision of the component it will be near impossible to leave that role at a
-company when moving on.
+and a vision of the component it will be near impossible to leave that role with a
+company when a coordinator moves on.
 
 It is encouraged that two people share the role of the coordinator for one
 component to enhance it's [Bus factor](https://en.wikipedia.org/wiki/Bus_factor).
@@ -39,7 +39,7 @@ component to enhance it's [Bus factor](https://en.wikipedia.org/wiki/Bus_factor)
 ## Change Management
 Everybody may contribute to any aspect of the component. Such contributions are
 handed in by pull requests or some other source of data if declared so in the
-components guidelines. Note that the general [contribution guideline](https://github.com/ILIAS-eLearning/ILIAS/blob/release_5-3/docs/documentation/contributing.md)
+component's guidelines. Note that the general [contribution guideline](https://github.com/ILIAS-eLearning/ILIAS/blob/release_5-3/docs/documentation/contributing.md)
 also apply for components managed by the coordinator model. The coordinator is
 called upon to define additional criteria and processes for the component (e.g.
 UI-components). This is the gain of this model: PRs cannot be rejected arbitrarily.
@@ -47,14 +47,14 @@ This allows other developers to build an expectation about the chances of their 
 Pull requests on the public interface must be accepted by the JF. The coordinator
 gives a recommendation to the JF on whether to accept or decline the PR. The
 decision of the JF may be implicit if no objections to the recommendation of the
-coordinator is made. If no agreement is achieved in the JF, the Technical Board
+coordinator are made. If no agreement is achieved in the JF, the Technical Board
 will decide upon the request. Further note, that in the case of two ore more people
 sharing the role of the coordinator, the feedback of one coordinator is enough for a
 request to be processed further. If both give feedback, the points of both
 coordinators must be respected. If the coordinators give contradictory feedback,
 the coordinators must resolve their differences before further processing.
 
-Final implementations without further changes on the interface do not need formal
+Final implementations without further changes to the interface do not need formal
 approval by the JF. The merge of the implementation is performed by the coordinator
 or the coordinator may assign somebody to do so.
 
@@ -74,8 +74,8 @@ focus on code quality, a low amount of bugs should be expected.
 This maintainance-model is suited for components that have the potential to grow
 too large to be handled by one single developer and therefore highly benefit
 from contributions from different developers and even service providers. It is
-further important that the component is of modular structure with different parts
-following a similar scheme. It is especially suited if some component is of a
+further important that the component has a modular structure with different parts
+following a similar scheme. It is especially suited if some component is of
 critical importance for many other components, since it is designed to allow a
 collaborative development of the vision for such a key-aspect.
 
@@ -90,17 +90,17 @@ decline changes.
 feedback for a change request, they MUST resolve the conflict as quickly as possible
 and publish a new feedback without contradictions.
 * If two or more people share the role of the coordinator they MUST define whom of
-them is contact person for Mantis bug reports as well as for other applicationsi
+them is the contact person for Mantis bug reports as well as for other applications
 that do not support more than one contact.
 * If two or more people share the role of the coordinator they MAY give feedback
 on different aspects of a change request. In such a case, both feedbacks MUST be
 considered.
 * The coordinator MUST accept decisions of the Technical Board on change requests
 in case of disagreement on the JF.
-* The coordinator MUST review final implementation of some accepted interface
-change or organize some substitute to perform the review.
+* The coordinator MUST review the final implementation of accepted interface
+changes or organize some substitute to perform the review.
 * The coordinator MAY ask for funding to perform a review.
-* The coordinator MAY ask to split some interface change or implementation into
+* The coordinator MAY ask to split an interface change or implementation into
 multiple pieces to make the change easier to understand.
 * The coordinator MUST ensure, that the documentation of the component is up to
 date. The coordinator MAY ask to update the documentation as a condition for
@@ -108,9 +108,9 @@ accepting some change request.
 * The coordinator MUST ensure, that the automated unit tests are kept up to date.
 The coordinator MAY ask other developers to write and update those tests in their
 own development.
-* The coordinator MUST assign unassigned issues to the responsible developer.
-* The coordinator SHOULD devise some guidelines concerning the processes around
-the respective component fitting it's exact needs as done so for the UI-Service.
+* The coordinator MUST assign unassigned issues concerning the component to the responsible developer.
+* The coordinator SHOULD devise some guidelines specifying the processes concerning
+the respective component in a way that fits it's exact needs. Have a look at the UI-Service for an example.
 Such guidelines MUST be accepted by the JF.
 * The coordinator MUST follow the rules given for the components, especially for
 contributing code. The coordinator has no special rights in this regard. E.g. if

--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -1,4 +1,4 @@
-# Coordinator Model
+# Maintainer Model
 
 ## Table of Contents
 
@@ -27,18 +27,18 @@ Maintainers take this responsibility for their specific component. Besides the
 maintenance they assure proper communication among developers that are working
 on the component.
 
-The Maintainer is understood to be the owner of a component and are basically the
-only ones that are permitted to make changes in a component. Decisions about
+The Maintainer is understood to be the owner of a component and is basically the
+only one that is permitted to make changes in it. Decisions about
 features in the component are made together with the product manager on the JF.
 This implies that mostly the maintainer is the only possible contractor for work
-on a component that should be included in the official ILIAS-core. The maintainer
+on a component that should be included in the official ILIAS-core. Maintainers
 may delegate the permission to make changes to other developers at their own
 discretion for specific parts of their component or even for the complete component.
 
 The PM and the TB appoint or replace maintainers. The maintainer role belongs to
 a person, not a company. Since the role builds on social capital in the community
-and a vision of the component, it will be near impossible to leave that role at
-a company when moving on.
+and a vision of the component, it will be near impossible to leave that role with
+a company when a maintainer moves on.
 
 It is encouraged that maintainers appoint second or even third maintainers for
 their respective components and introduce them to the inner workings of the
@@ -52,14 +52,14 @@ changes in or removal of an existing feature) are decided upon by the maintainer
 of a component together with the product manager on the Jour Fixe, according
 to the process to handle [feature requests](http://www.ilias.de/docu/goto.php?target=wiki_5307&client_id=docu#ilPageTocA119).
 
-Changes in the code of a component are privilege of the maintainer, which might
+Changes in the code of a component are the privilege of the maintainer, which might
 be delegated to other developers. Proposals for bugfixes or improvements of some
-component can be handed by contributors according to the [guidelines for contributions](contributing.md)
+component can be handed in by contributors according to the [guidelines for contributions](contributing.md)
 and are recognized by responsible maintainers.
 
 <a name="issue-management"></a>
 ## Issue Management
-Issues with components are handed in a the [Issue-Tracker](http://mantis.ilias.de).
+Issues with components are handed in through the [Issue-Tracker](http://mantis.ilias.de).
 They are assigned to the responsible maintainer automatically and are handled
 according to the [bug fixing process](https://docu.ilias.de/goto_docu_file_4566_download.html).
 

--- a/docs/development/maintenance.md
+++ b/docs/development/maintenance.md
@@ -1,39 +1,92 @@
-ILIAS Maintenance
-=================
-The development of the ILIAS source code is coordinated and maintained by a coordination team within the ILIAS network. Besides the main responsibilities for the project, several developers and users are maintaining certain modules of ILIAS.
+# Coordinator Model
 
-# Special Roles
+## Table of Contents
 
-* **Product Management**: [Matthias Kunkel]
-* **Technical Board**: [Alexander Killing], [Michael Jansen], [Timon Amstutz], [Richard Klees], [Stephan Winiker]
-* **Testcase Management**: [Fabian Kruse]
-* **Documentation**: [Florian Suittenpointner]
-* **Online Help**: [Alexandra Tödt]
-
-# Maintainers
-We highly appreciate to get new developers but we have to guarantee the sustainability and the quality of the ILIAS source code. The system is complex for new developers and they need to know the concepts of ILIAS that are described in the development guide.
- 
-Communication among developers that are working on a specific component needs to be assured. Final decision about getting write access to the ILIAS development system (Github) is handled by the product manager.
- 
-ILIAS is currently maintained by three types of Maintainerships:
-
-- First Component Maintainer
-- Second Component Maintainer
-- [Coordinator Model](maintenance-coordinator.md) 
- 
-The following rules must be respected for everyone involved in the programming of ILIAS for all components having a listed component maintainer (see bellow):
-
-1. Decisions on new features or feature removals are made by the responsible first maintainer and the product manager in the Jour Fixe meetings after an open discussion.
-2. All components have a first and second maintainer. Code changes are usually done by the first maintainer. The first maintainer may forward new implementations to the second maintainer.
-
-Responsibilities of a component maintainer:
-
-- Component maintainer must assure maintenance of their component for at least three years (approx. three ILIAS major releases).
-- Component maintainers must agree to coordinate the development of their component with the product manager.
-- Component maintainer are responsible for bug fixing of their component and get assigned related bugs automatically by the [Issue-Tracker](http://mantis.ilias.de).
+<!-- MarkdownTOC depth=0 autolink="true" bracket="round" autoanchor="true" style="ordered" indent="   " -->
+1. [Role of the Maintainer](#role-of-the-maintainer)
+1. [Change Management](#change-management)
+1. [Issue Management](#issue-management)
+1. [Scenarios](#scenarios)
+1. [What can be expected of a coordinator?](#expectations)
 
 
-The code base is deviced in several components:
+<!-- /MarkdownTOC -->
+<a name="role-of-the-maintainer"></a>
+## Role of the Maintainer
+
+Each component ([Module](../../Modules), [Service](../../Service), [Library](../../src)
+and some special cases as language-files) is either maintained by a maintainer
+or collectively maintained within the [Coordinator Model](maintenance-coordinator.md).
+
+New developers are welcome to the project, but the system has reached a certain
+complexity in code as well as in features that could be hard to grasp for newcomers.
+Even if we try to document our system better and simplify where possible, we still
+need to guarantee the sustainability and quality of our development process.
+
+Maintainers take this responsibility for their specific component. Besides the
+maintenance they assure proper communication among developers that are working
+on the component.
+
+The Maintainer is understood to be the owner of a component and are basically the
+only ones that are permitted to make changes in a component. Decisions about
+features in the component are made together with the product manager on the JF.
+This implies that mostly the maintainer is the only possible contractor for work
+on a component that should be included in the official ILIAS-core. The maintainer
+may delegate the permission to make changes to other developers at their own
+discretion for specific parts of their component or even for the complete component.
+
+The PM and the TB appoint or replace maintainers. The maintainer role belongs to
+a person, not a company. Since the role builds on social capital in the community
+and a vision of the component, it will be near impossible to leave that role at
+a company when moving on.
+
+It is encouraged that maintainers appoint second or even third maintainers for
+their respective components and introduce them to the inner workings of the
+component to enhance the component's [Bus factor](https://en.wikipedia.org/wiki/Bus_factor).
+
+
+<a name="change-management"></a>
+## Change Management
+Changes of features of the component (be it introduction of a new feature,
+changes in or removal of an existing feature) are decided upon by the maintainer
+of a component together with the product manager on the Jour Fixe, according
+to the process to handle [feature requests](http://www.ilias.de/docu/goto.php?target=wiki_5307&client_id=docu#ilPageTocA119).
+
+Changes in the code of a component are privilege of the maintainer, which might
+be delegated to other developers. Proposals for bugfixes or improvements of some
+component can be handed by contributors according to the [guidelines for contributions](contributing.md)
+and are recognized by responsible maintainers.
+
+<a name="issue-management"></a>
+## Issue Management
+Issues with components are handed in a the [Issue-Tracker](http://mantis.ilias.de).
+They are assigned to the responsible maintainer automatically and are handled
+according to the [bug fixing process](https://docu.ilias.de/goto_docu_file_4566_download.html).
+
+<a name="scenarios"></a>
+## Scenarios
+
+TBD
+
+<a name="expectations"></a>
+## What can be expected of a maintainer?
+* Component maintainers MUST assure maintenance of their component for at least
+three year which is approximately three ILIAS major releases.
+* Component maintainers MUST agree to coordinate the development of their component
+with the product manager. The decisions on new features or the removal of existing
+features MUST be made by the responsible first maintainer and the product manager
+on the Jour Fixe after an open discussion.
+* Component maintainers SHOULD fix bugs in components they are responsible for.
+Tickets related to their component are automatically assigned by the [Issue-Tracker](http://mantis.ilias.de).
+* Component maintainers MUST handle PRs according to our [contribution guidelines](contributing.md#rules-for-maintainers-assigned-to-prs).
+
+TBD
+
+**Please note:** The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
+NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and  "OPTIONAL"  in this
+document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+# Listing of Maintainers
 
 <!-- REMOVE -->
 * **ActiveRecord**


### PR DESCRIPTION
Hallo zusammen!

Ich hatte noch den Auftrag die `maintenance.md` so zu verbessern, dass sie analog zur `maintenance-coordinator.md` zu lesen ist. Das habe ich hier versucht.

Ich habe versucht, nichts hinzuzufügen, was nicht schon drin war, gelebte Praxis ist oder woanders definiert ist. Ich sehe aber, dass es Punkte gibt, die wir wahrscheinlich hinzufügen sollten, zumindenstens hätte ich den einen oder anderen.

Den Abschnitt "Szenarios" konnte ich nicht sinnvoll ausfüllen. Ehrlicherweise hätte ich hier sowas hinschreiben müssen wie "Wenn das schon immer so gemacht wurde.", aber das ist sicher nicht sinnvoll.

Mir ist weiterhin an dem Wording in dem ursprünglichen Dokument klar geworden, dass es wahrscheinlich aus einer Zeit kommt, in dem ein Großteil der Entwicklung von einem "Core Team" gemacht wurde und nur einige wenige Komponenten an "Component Maintainer" herausgegeben wurden. Das fand ich insofern interessant, als dass es mir einen Hinweis gibt, wodurch einige der von mir und anderen wahrgenommen Probleme mit dem Maintainermodell hervorgerufen werden, nämlich das es aus einer Zeit mit deutlich stärker zentralisierter Entwicklung kommt.

Schließlich ist mir beim Aufschreiben nochmal klar geworden, warum es mit dem aktuellen Verständnis von Maintainerschaft schwierig wird, diese Aufgaben und Verantwortung an Firmen zu übergeben.

Ich bin mir nicht sicher, wie wir die Diskussion weiterführen wollen (hier, Forum, live, ...) und habe meine Gedanken daher erstmal hier frisch reingepackt. Ich setze das Thema auf unser nächstes Meeting und freue mich ansonsten auf unmittelbares Feedback zum Text in diesem PR und sonstiges Feedback hier oder sonstwo.

Beste Grüße!